### PR TITLE
Release mechanism added for release on git tag v*

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -1,0 +1,112 @@
+# This creates release on pushing with tag
+
+name: tag-and-release
+
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+defaults:
+  run:
+    working-directory: cli
+
+jobs:
+ 
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+        matrix:
+            os: [ubuntu-latest, windows-2019, macos-latest ]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Get the version
+      id: get_version
+      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      shell: bash
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+      with:
+        tag_name: ${{ steps.get_version.outputs.VERSION }}
+        release_name: Release ${{steps.get_version.outputs.VERSION}}
+        draft: true
+
+    - name: Install graalvm
+      uses: DeLaGuardo/setup-graalvm@3
+      with:
+        graalvm-version: '20.0.0.java11'
+    
+    # Install Native Image,Set Version and Build from Linux and MACOS
+    - if: matrix.os != 'windows-2019' 
+      name: Install native-image
+      run: gu install native-image
+    - if: matrix.os != 'windows-2019' 
+      name: Set version
+      run: ./mvnw versions:set -DnewVersion="${{steps.get_version.outputs.VERSION}}" 
+    - if: matrix.os != 'windows-2019' 
+      name: Build native executable
+      run: ./mvnw package -Dnative 
+      
+     # Install Native Image,Set Version and Build from Windows
+    - if: matrix.os == 'windows-2019'
+      name: Install native-image
+      run: |
+        %JAVA_HOME%/bin/gu.cmd install native-image
+      shell: cmd
+    - if: matrix.os == 'windows-2019'
+      name: Configure Pagefile
+      # Increased the page-file size due to memory-consumption of native-image command
+      # For details see https://github.com/actions/virtual-environments/issues/785
+      uses: al-cheb/configure-pagefile-action@v1.2
+    - if: matrix.os == 'windows-2019'
+      name: Set version
+      run: mvnw versions:set -DnewVersion="${{ steps.get_version.outputs.VERSION }}"
+      shell: cmd
+    - if: matrix.os == 'windows-2019'
+      name: Build native executable
+      # Invoke the native-image build with the necessary Visual Studio tooling/environment intialized
+      run: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
+        mvnw package -Dnative"
+      shell: cmd
+    
+    - if: matrix.os == 'ubuntu-latest' 
+      name: Upload native executable Linux
+      id: upload-native-executable-linux
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./cli/target/starfish-${{steps.get_version.outputs.VERSION}}.zip 
+        asset_name: starfish-linux.zip
+        asset_content_type: application/octet-stream
+
+    - if: matrix.os == 'windows-2019' 
+      name: Upload native executable Windows
+      id: upload-native-executable-windows
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./cli/target/starfish-${{steps.get_version.outputs.VERSION}}.zip 
+        asset_name: starfish-win64.zip
+        asset_content_type: application/octet-stream
+
+    - if: matrix.os == 'macos-latest' 
+      name: Upload native executable macos
+      id: upload-native-executable-macos
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./cli/target/starfish-${{steps.get_version.outputs.VERSION}}.zip 
+        asset_name: starfish-macos.zip
+        asset_content_type: application/octet-stream

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -96,7 +96,7 @@ jobs:
       with:
         upload_url: ${{ needs.createrelease.outputs.release_url }}
         asset_path: ./cli/target/starfish-${{needs.createrelease.outputs.version}}.zip 
-        asset_name: starfish-linux.zip
+        asset_name: starfish-${{needs.createrelease.outputs.version}}-linux.zip
         asset_content_type: application/octet-stream
 
     - if: matrix.os == 'windows-2019' 
@@ -108,7 +108,7 @@ jobs:
       with:
         upload_url: ${{ needs.createrelease.outputs.release_url }}
         asset_path: ./cli/target/starfish-${{needs.createrelease.outputs.version}}.zip 
-        asset_name: starfish-win64.zip
+        asset_name: starfish-${{needs.createrelease.outputs.version}}-win64.zip
         asset_content_type: application/octet-stream
 
     - if: matrix.os == 'macos-latest' 
@@ -120,5 +120,5 @@ jobs:
       with:
         upload_url: ${{ needs.createrelease.outputs.release_url}}
         asset_path: ./cli/target/starfish-${{needs.createrelease.outputs.version}}.zip 
-        asset_name: starfish-macos.zip
+        asset_name: starfish-${{needs.createrelease.outputs.version}}-macos.zip
         asset_content_type: application/octet-stream

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -13,29 +13,40 @@ defaults:
     working-directory: cli
 
 jobs:
+  createrelease:
+    name: createrelease
+    runs-on: [ubuntu-latest]
+    outputs:
+      release_url: ${{ steps.create_release.outputs.upload_url }}
+      version: ${{ steps.get_version.outputs.VERSION }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        shell: bash
+      - name: create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.get_version.outputs.VERSION  }}
+          release_name: Release ${{ steps.get_version.outputs.VERSION  }}
+          prerelease: false
+          draft: true
+   
  
   build:
-
-    runs-on: ${{ matrix.os }}
+    needs: [createrelease]
+    name: build
     strategy:
         matrix:
             os: [ubuntu-latest, windows-2019, macos-latest ]
+    runs-on: ${{ matrix.os }}
+    
     steps:
     - uses: actions/checkout@v2
-    - name: Get the version
-      id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-      shell: bash
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
-      with:
-        tag_name: ${{ steps.get_version.outputs.VERSION }}
-        release_name: Release ${{steps.get_version.outputs.VERSION}}
-        draft: true
-
     - name: Install graalvm
       uses: DeLaGuardo/setup-graalvm@3
       with:
@@ -47,7 +58,7 @@ jobs:
       run: gu install native-image
     - if: matrix.os != 'windows-2019' 
       name: Set version
-      run: ./mvnw versions:set -DnewVersion="${{steps.get_version.outputs.VERSION}}" 
+      run: ./mvnw versions:set -DnewVersion="${{needs.createrelease.outputs.version}}" 
     - if: matrix.os != 'windows-2019' 
       name: Build native executable
       run: ./mvnw package -Dnative 
@@ -65,7 +76,7 @@ jobs:
       uses: al-cheb/configure-pagefile-action@v1.2
     - if: matrix.os == 'windows-2019'
       name: Set version
-      run: mvnw versions:set -DnewVersion="${{ steps.get_version.outputs.VERSION }}"
+      run: mvnw versions:set -DnewVersion="${{ needs.createrelease.outputs.version }}"
       shell: cmd
     - if: matrix.os == 'windows-2019'
       name: Build native executable
@@ -74,6 +85,7 @@ jobs:
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
         mvnw package -Dnative"
       shell: cmd
+      
     
     - if: matrix.os == 'ubuntu-latest' 
       name: Upload native executable Linux
@@ -82,8 +94,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./cli/target/starfish-${{steps.get_version.outputs.VERSION}}.zip 
+        upload_url: ${{ needs.createrelease.outputs.release_url }}
+        asset_path: ./cli/target/starfish-${{needs.createrelease.outputs.version}}.zip 
         asset_name: starfish-linux.zip
         asset_content_type: application/octet-stream
 
@@ -94,8 +106,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./cli/target/starfish-${{steps.get_version.outputs.VERSION}}.zip 
+        upload_url: ${{ needs.createrelease.outputs.release_url }}
+        asset_path: ./cli/target/starfish-${{needs.createrelease.outputs.version}}.zip 
         asset_name: starfish-win64.zip
         asset_content_type: application/octet-stream
 
@@ -106,7 +118,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./cli/target/starfish-${{steps.get_version.outputs.VERSION}}.zip 
+        upload_url: ${{ needs.createrelease.outputs.release_url}}
+        asset_path: ./cli/target/starfish-${{needs.createrelease.outputs.version}}.zip 
         asset_name: starfish-macos.zip
         asset_content_type: application/octet-stream

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -32,7 +32,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.get_version.outputs.VERSION  }}
-          release_name: Release ${{ steps.get_version.outputs.VERSION  }}
+          release_name: ${{ steps.get_version.outputs.VERSION  }}
           prerelease: false
           draft: true
    


### PR DESCRIPTION
- setup workflow that on git tag v* (i.e. git tag v0.0.1) builds and create a draft release. 
- Issue: #22 
